### PR TITLE
#164165707 Add Ansible provisioner

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,2 @@
+playbook.main.retry
+.DS_Store

--- a/ansible/playbook.main.yml
+++ b/ansible/playbook.main.yml
@@ -1,0 +1,18 @@
+---
+- hosts: 127.0.0.1
+  remote_user: ubuntu
+  become: yes
+  become_method: sudo
+  vars_files: 
+    - ./vars.yml
+  #Tasks in this play are here 
+  roles:
+  - os_update
+  - clone_repo
+  - setup_app
+  # config handlers to restart NGINX service when it has been notified above
+  handlers:
+    - name: restart nginx
+      service:
+        name: nginx
+        state: restarted

--- a/ansible/roles/clone_repo/tasks/main.yml
+++ b/ansible/roles/clone_repo/tasks/main.yml
@@ -1,0 +1,8 @@
+# Clone the project repository
+- name: Clone Github repository
+  git:
+    repo: "{{ REPO_URL }}"
+    dest: "/home/ubuntu/Events-Manager"
+    clone: yes
+    version: chore/deploy-on-aws/158841810
+    

--- a/ansible/roles/os_update/tasks/main.yml
+++ b/ansible/roles/os_update/tasks/main.yml
@@ -1,0 +1,36 @@
+- name: Update Ubuntu OS
+  apt:
+    upgrade: "yes"
+    update_cache: "yes"
+  #Install NGINX
+- name: Installing nginx
+  apt:
+    name: nginx
+    state: latest
+  
+# Start the NGINX service after installation
+- name: ensure NGINX is running
+  service:
+    name: nginx
+    state: started
+
+  # Install Nodejs
+- name: Installing the gpg key for nodejs LTS
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: Install NODEJS LTS repos
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/node_{{ NODEJS_VERSION }}.x {{ ansible_distribution_release }} main"
+    state: present
+    update_cache: yes 
+
+- name: Installing NODEJS
+  apt: 
+    name: nodejs
+    state: present
+
+# Install PM2 for background process running
+- name: Install PM2
+  command: npm install -g pm2

--- a/ansible/roles/setup_app/tasks/main.yml
+++ b/ansible/roles/setup_app/tasks/main.yml
@@ -1,0 +1,52 @@
+#Remove default NGINX config and replace with app config
+- name: pre-configure NGINX removing default files
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  ignore_errors: yes
+
+- name: check if there a previous config and deletes
+  file:
+    path: /etc/nginx/sites-available/nginx-router
+    state: absent
+  ignore_errors: yes
+
+- name: Replace default NGINX config with user config
+  command: |
+    bash -c 'cat > /etc/nginx/sites-available/nginx-router <<EOF
+      server {
+        listen 80;
+        location / {
+          proxy_pass        http://127.0.0.1:5050;
+        }
+    }
+    EOF'
+
+- name: Create symnlink between the sites available and sites enabled dirs
+  file:
+    src: /etc/nginx/sites-available/nginx-router
+    dest: /etc/nginx/sites-enabled/nginx-router
+    state: link
+  notify:
+  - restart nginx
+
+# Install PM2 for background process running
+- name: Install PM2
+  command: npm install -g pm2
+
+# Install npm dependencies 
+# run build
+# use pm2 to startup app
+# configure pm2 to run app as a service
+- name: Install NPM dependencies
+  shell: |
+    cd /home/ubuntu/Events-Manager
+    export NODE_ENV=production
+    sudo npm install --unsafe-perm
+    sudo npm run build
+    echo ""
+    sudo pm2 start server/lib/server.js
+    sleep 20
+    sudo pm2 startup
+    sudo env PATH=$PATH:/usr/bin /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u ubuntu --hp /home/ubuntu
+    sudo pm2 save

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -1,0 +1,3 @@
+---
+NODEJS_VERSION: 8
+REPO_URL: https://github.com/iidrees/Events-Manager.git

--- a/packer/ansible.sh
+++ b/packer/ansible.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# File: Ansible
+
+set -x
+# Install ansibele to setup server configuration process
+function ansible {
+  sudo apt-get update -y
+  sudo apt-get install software-properties-common -y
+  sudo apt-add-repository ppa:ansible/ansible -y
+  sudo apt-get update -y
+  sudo apt-get install ansible -y
+}
+
+ansible

--- a/packer/ubuntu_image.json
+++ b/packer/ubuntu_image.json
@@ -32,5 +32,16 @@
       "OS": "Linux Ubuntu",
       "maintaner": "Ibraheem Idrees"
     }
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "script": "./ansible.sh"
+  },
+  {
+    "type": "ansible-local",
+    "playbook_file": "../ansible/playbook.main.yml",
+    "extra_arguments": [ "-vvvv" ],
+    "playbook_dir": "../ansible",
+    "role_paths":  ["../ansible/roles"]
   }]
 }


### PR DESCRIPTION
#### Why's this important?

when you build an `AMI` instead of manually provisioning the instance and then installing packages and running OS updates, you should be able to automate these steps by using `Ansible` to provision the `packer image`
Using `Packer and Ansible` one should be able to create a machine image and provision the same image and set it up to be ready for deployment.